### PR TITLE
Precarga de los personajes antes de acceder a la Colección

### DIFF
--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -8,7 +8,6 @@ import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
 import ar.edu.unlam.mobile.scaffold.domain.hero.Powerstats
 import ar.edu.unlam.mobile.scaffold.domain.hero.toHeroEntityModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
@@ -24,7 +23,6 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
             emit(0f)
             for (i in 1..COLLECTION_MAX_SIZE) {
                 getHero(i)
-                delay(100L)
                 val percentage = i / COLLECTION_MAX_SIZE.toFloat()
                 emit(percentage)
             }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -18,11 +18,12 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
     IHeroRepository {
 
     // private val API_COLLECTION_SIZE = 731 // no eliminar
-    private val COLLECTION_MAX_SIZE = 50 // es menor o igual a API_COLLECTION_SIZE
+    private val COLLECTION_MAX_SIZE = 731 // es menor o igual a API_COLLECTION_SIZE
 
 
     override fun preloadHeroCache(): Flow<Float> {
         return flow<Float> {
+            emit(0f)
             for(i in 1..COLLECTION_MAX_SIZE) {
                 getHero(i)
                 val percentage = i / COLLECTION_MAX_SIZE.toFloat() * 100

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -8,35 +8,34 @@ import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
 import ar.edu.unlam.mobile.scaffold.domain.hero.Powerstats
 import ar.edu.unlam.mobile.scaffold.domain.hero.toHeroEntityModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
 
 class HeroRepository @Inject constructor(private val api: HeroService, private val dataBase: HeroDao) :
     IHeroRepository {
 
     // private val API_COLLECTION_SIZE = 731 // no eliminar
     private val COLLECTION_MAX_SIZE = 731 // es menor o igual a API_COLLECTION_SIZE
-
-
     override fun preloadHeroCache(): Flow<Float> {
         return flow<Float> {
             emit(0f)
-            for(i in 1..COLLECTION_MAX_SIZE) {
+            for (i in 1..COLLECTION_MAX_SIZE) {
                 getHero(i)
+                delay(1000L) // solo es para testing, borrar esta linea después
                 val percentage = i / COLLECTION_MAX_SIZE.toFloat() * 100
                 emit(percentage)
             }
         }
     }
 
-    override suspend fun getAdversaryDeck(size:Int): List<DataHero> {
+    override suspend fun getAdversaryDeck(size: Int): List<DataHero> {
         return getRandomPlayerDeck(size)
     }
 
-    override suspend fun getRandomPlayerDeck(size:Int): List<DataHero> {
+    override suspend fun getRandomPlayerDeck(size: Int): List<DataHero> {
         val list = mutableListOf<DataHero>()
         return withContext(Dispatchers.IO) {
             for (i in 1..size) {
@@ -48,9 +47,9 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
         }
     }
     private fun formatDataHero(h: DataHero): DataHero {
-        return if(isPowerStatsNull(h)) convertNullPowerstatsToNotNull(h) else h
+        return if (isPowerStatsNull(h)) convertNullPowerstatsToNotNull(h) else h
     }
-    private fun isPowerStatsNull(h: DataHero):Boolean {
+    private fun isPowerStatsNull(h: DataHero): Boolean {
         return h.powerstats.power == "null"
     }
 
@@ -86,8 +85,8 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
         val heroList = mutableListOf<DataHero>()
         val saveToDbList = mutableListOf<HeroEntity>()
 
-        if(dbList.isNotEmpty()) {
-            for(i in 1..COLLECTION_MAX_SIZE) {
+        if (dbList.isNotEmpty()) {
+            for (i in 1..COLLECTION_MAX_SIZE) {
                 val heroDb = dbList.find { it.id == i }
                 if (heroDb != null) {
                     heroList.add(heroDb.toHeroModel())
@@ -98,7 +97,7 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
                 }
             }
         } else {
-            for(i in 1..COLLECTION_MAX_SIZE) {
+            for (i in 1..COLLECTION_MAX_SIZE) {
                 val heroApi = formatDataHero(api.getHero(i))
                 saveToDbList.add(heroApi.toHeroEntityModel())
                 heroList.add(heroApi)

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -20,12 +20,12 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
     // private val API_COLLECTION_SIZE = 731 // no eliminar
     private val COLLECTION_MAX_SIZE = 731 // es menor o igual a API_COLLECTION_SIZE
     override fun preloadHeroCache(): Flow<Float> {
-        return flow<Float> {
+        return flow {
             emit(0f)
             for (i in 1..COLLECTION_MAX_SIZE) {
                 getHero(i)
-                delay(1000L) // solo es para testing, borrar esta linea después
-                val percentage = i / COLLECTION_MAX_SIZE.toFloat() * 100
+                delay(100L)
+                val percentage = i / COLLECTION_MAX_SIZE.toFloat()
                 emit(percentage)
             }
         }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -8,6 +8,8 @@ import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
 import ar.edu.unlam.mobile.scaffold.domain.hero.Powerstats
 import ar.edu.unlam.mobile.scaffold.domain.hero.toHeroEntityModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -17,6 +19,17 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
 
     // private val API_COLLECTION_SIZE = 731 // no eliminar
     private val COLLECTION_MAX_SIZE = 50 // es menor o igual a API_COLLECTION_SIZE
+
+
+    override fun preloadHeroCache(): Flow<Float> {
+        return flow<Float> {
+            for(i in 1..COLLECTION_MAX_SIZE) {
+                getHero(i)
+                val percentage = i / COLLECTION_MAX_SIZE.toFloat() * 100
+                emit(percentage)
+            }
+        }
+    }
 
     override suspend fun getAdversaryDeck(size:Int): List<DataHero> {
         return getRandomPlayerDeck(size)

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepositoryManualTest.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepositoryManualTest.kt
@@ -1,8 +1,9 @@
 package ar.edu.unlam.mobile.scaffold.data.repository
 
-import ar.edu.unlam.mobile.scaffold.data.repository.IHeroRepository
+
 import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
 import ar.edu.unlam.mobile.scaffold.domain.hero.Powerstats
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class HeroRepositoryManualTest @Inject constructor(): IHeroRepository {
@@ -80,10 +81,6 @@ class HeroRepositoryManualTest @Inject constructor(): IHeroRepository {
         return listOf(hero1,hero2,hero3)
     }
 
-    suspend fun getPlayerDeck(idDeck: Int): List<DataHero> {
-        return heroListTest1()
-    }
-
 
     override suspend fun getAdversaryDeck(size: Int): List<DataHero> {
         return heroListTest2()
@@ -106,6 +103,10 @@ class HeroRepositoryManualTest @Inject constructor(): IHeroRepository {
             )
         }
         return dataHeroTestList
+    }
+
+    override fun preloadHeroCache(): Flow<Float> {
+        TODO("Not yet implemented")
     }
 
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/IHeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/IHeroRepository.kt
@@ -1,6 +1,7 @@
 package ar.edu.unlam.mobile.scaffold.data.repository
 
 import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
+import kotlinx.coroutines.flow.Flow
 
 interface IHeroRepository {
 
@@ -8,4 +9,5 @@ interface IHeroRepository {
     suspend fun getAdversaryDeck(size:Int): List<DataHero>
     suspend fun getHero(heroId:Int): DataHero
     suspend fun getAllHero():List<DataHero>
+    fun preloadHeroCache(): Flow<Float>
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/CustomProgressBar.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/CustomProgressBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import ar.edu.unlam.mobile.scaffold.ui.theme.shaka_pow
 
 @Preview
 @Composable
@@ -46,7 +47,7 @@ fun CustomProgressBar(
         targetValue = barProgress,
         tween(
             durationMillis = 1000,
-            delayMillis = 200,
+            delayMillis = 0,
             easing = LinearOutSlowInEasing
         ),
         label = "Custom Progress Bar Animation"
@@ -55,13 +56,13 @@ fun CustomProgressBar(
     Box(
         modifier = modifier
             .height(height)
-            .clip(RoundedCornerShape(height / 0.75.dp))
+            .clip(RoundedCornerShape(30.dp))
     ) {
         // background
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .clip(RoundedCornerShape(height / 0.75.dp))
+                .clip(RoundedCornerShape(30.dp))
                 .background(backgroundColor)
         )
         // foreground
@@ -69,7 +70,7 @@ fun CustomProgressBar(
             modifier = Modifier
                 .fillMaxWidth(size)
                 .fillMaxHeight()
-                .clip(RoundedCornerShape(height / 0.75.dp))
+                .clip(RoundedCornerShape(30.dp))
                 .background(foregroundColor)
                 .animateContentSize()
         )
@@ -93,7 +94,8 @@ fun CustomProgressBarWithDots(
             val cacheProgress = "%.2f".format(progress * 100f)
             Text(
                 modifier = Modifier.padding(top = 9.dp),
-                text = "Loading: $cacheProgress%"
+                text = "Loading: $cacheProgress%",
+                fontFamily = shaka_pow
             )
             LoadingAnimation(
                 modifier = Modifier

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/CustomProgressBar.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/CustomProgressBar.kt
@@ -1,0 +1,107 @@
+package ar.edu.unlam.mobile.scaffold.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Preview
+@Composable
+fun CustomProgressBar(
+    modifier: Modifier = Modifier,
+    progress: Float = 0.6f,
+    height: Dp = 40.dp,
+    backgroundColor: Color = Color.Cyan,
+    foregroundColor: Color = Color.Yellow,
+    content: @Composable (BoxScope.() -> Unit) = {}
+) {
+    var barProgress by remember {
+        mutableStateOf(0f)
+    }
+    val size by animateFloatAsState(
+        targetValue = barProgress,
+        tween(
+            durationMillis = 1000,
+            delayMillis = 200,
+            easing = LinearOutSlowInEasing
+        ),
+        label = "Custom Progress Bar Animation"
+    )
+    // Progress Bar
+    Box(
+        modifier = modifier
+            .height(height)
+            .clip(RoundedCornerShape(height / 0.75.dp))
+    ) {
+        // background
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(height / 0.75.dp))
+                .background(backgroundColor)
+        )
+        // foreground
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(size)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(height / 0.75.dp))
+                .background(foregroundColor)
+                .animateContentSize()
+        )
+        content()
+    }
+    LaunchedEffect(key1 = progress) {
+        barProgress = progress
+    }
+}
+
+@Composable
+fun CustomProgressBarWithDots(
+    modifier: Modifier = Modifier,
+    progress: Float = 0f
+) {
+    CustomProgressBar(modifier = modifier, progress = progress) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            val cacheProgress = "%.2f".format(progress * 100f)
+            Text(
+                modifier = Modifier.padding(top = 9.dp),
+                text = "Loading: $cacheProgress%"
+            )
+            LoadingAnimation(
+                modifier = Modifier
+                    .padding(start = 10.dp, top = 15.dp),
+                circleSize = 15.dp,
+                spaceBetween = 5.dp,
+                travelDistance = 15.dp
+            )
+        }
+    }
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/LoadingAnimation.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/components/LoadingAnimation.kt
@@ -1,0 +1,82 @@
+package ar.edu.unlam.mobile.scaffold.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Preview
+@Composable
+fun LoadingAnimation(
+    modifier: Modifier = Modifier,
+    circleSize: Dp = 25.dp,
+    circleColor: Color = Color.Red,
+    spaceBetween: Dp = 10.dp,
+    travelDistance: Dp = 20.dp,
+    delayOfEachCircleAnimation: Long = 100L,
+    durationMilliseconds: Int = 1200
+) {
+    val circles = listOf(
+        remember { Animatable(initialValue = 0f) },
+        remember { Animatable(initialValue = 0f) },
+        remember { Animatable(initialValue = 0f) }
+    )
+    circles.forEachIndexed { index, animatable ->
+        LaunchedEffect(key1 = animatable) {
+            delay(index * delayOfEachCircleAnimation)
+            animatable.animateTo(
+                targetValue = 1f,
+                animationSpec = infiniteRepeatable(
+                    animation = keyframes {
+                        durationMillis = durationMilliseconds
+                        0f at 0 with LinearOutSlowInEasing
+                        1f at durationMilliseconds / 4 with LinearOutSlowInEasing
+                        0f at durationMilliseconds / 2 with LinearOutSlowInEasing
+                        0f at durationMilliseconds with LinearOutSlowInEasing
+                    },
+                    repeatMode = RepeatMode.Restart
+                )
+            )
+        }
+    }
+    val circleValues = circles.map { it.value }
+    val distance = with(LocalDensity.current) {
+        travelDistance.toPx()
+    }
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spaceBetween)
+    ) {
+        circleValues.forEach { value ->
+            Box(
+                modifier = Modifier
+                    .size(circleSize)
+                    .graphicsLayer {
+                        translationY = -value * distance
+                    }
+                    .background(
+                        color = circleColor,
+                        shape = CircleShape
+                    )
+            )
+        }
+    }
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
@@ -86,19 +86,6 @@ fun HomeScreen(
                 controller.navigate(route = "quiz")
             }
             if (cacheProgress < 1f) {
-                /*
-                Button(onClick = { }) {
-                    Text(text = "Loading: $cacheProgress%")
-                    LoadingAnimation(
-                        modifier = Modifier
-                            .padding(start = 10.dp, top = 10.dp),
-                        circleSize = 15.dp,
-                        spaceBetween = 5.dp,
-                        travelDistance = 15.dp
-                    )
-                }
-
-                 */
                 CustomProgressBarWithDots(modifier = navButtonModifier, progress = cacheProgress)
             } else {
                 NavigationButton(

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
@@ -23,10 +23,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import ar.edu.unlam.mobile.scaffold.R
+import ar.edu.unlam.mobile.scaffold.ui.components.LoadingAnimation
 import ar.edu.unlam.mobile.scaffold.ui.theme.shaka_pow
 
 @Composable
-fun NavigationButton(modifier : Modifier = Modifier,text: String = "button",onClick: () -> Unit) {
+fun NavigationButton(
+    modifier: Modifier = Modifier,
+    text: String = "button",
+    onClick: () -> Unit
+) {
     Button(
         onClick = {
             onClick()
@@ -35,7 +40,8 @@ fun NavigationButton(modifier : Modifier = Modifier,text: String = "button",onCl
         colors = ButtonDefaults.buttonColors(Color.Yellow)
     ) {
         Text(
-            text = text, fontSize = 20.sp,
+            text = text,
+            fontSize = 20.sp,
             color = Color.Black,
             fontFamily = shaka_pow
         )
@@ -48,9 +54,7 @@ fun HomeScreen(
     viewModel: HomeViewmodel = hiltViewModel(),
     controller: NavHostController
 ) {
-
     val cacheProgress by viewModel.cachingProgress.collectAsStateWithLifecycle()
-
     val navButtonModifier = Modifier
         .wrapContentSize()
         .padding(16.dp)
@@ -81,14 +85,22 @@ fun HomeScreen(
             ) {
                 controller.navigate(route = "quiz")
             }
-            NavigationButton(
-                modifier = navButtonModifier,
-                text = "Coleccion"
-            ) {
-                controller.navigate(route = "collection")
+            if (cacheProgress < 100f) {
+                Button(onClick = { }) {
+                    Text(text = "Loading: $cacheProgress%")
+                    LoadingAnimation(
+                        modifier = Modifier
+                            .padding(start = 10.dp)
+                    )
+                }
+            } else {
+                NavigationButton(
+                    modifier = navButtonModifier,
+                    text = "Coleccion"
+                ) {
+                    controller.navigate(route = "collection")
+                }
             }
-            Text(text = "$cacheProgress")
         }
     }
 }
-

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
@@ -23,7 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import ar.edu.unlam.mobile.scaffold.R
-import ar.edu.unlam.mobile.scaffold.ui.components.LoadingAnimation
+import ar.edu.unlam.mobile.scaffold.ui.components.CustomProgressBarWithDots
 import ar.edu.unlam.mobile.scaffold.ui.theme.shaka_pow
 
 @Composable
@@ -85,7 +85,8 @@ fun HomeScreen(
             ) {
                 controller.navigate(route = "quiz")
             }
-            if (cacheProgress < 100f) {
+            if (cacheProgress < 1f) {
+                /*
                 Button(onClick = { }) {
                     Text(text = "Loading: $cacheProgress%")
                     LoadingAnimation(
@@ -96,6 +97,9 @@ fun HomeScreen(
                         travelDistance = 15.dp
                     )
                 }
+
+                 */
+                CustomProgressBarWithDots(modifier = navButtonModifier, progress = cacheProgress)
             } else {
                 NavigationButton(
                     modifier = navButtonModifier,

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,6 +19,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import ar.edu.unlam.mobile.scaffold.R
 import ar.edu.unlam.mobile.scaffold.ui.theme.shaka_pow
@@ -42,10 +45,15 @@ fun NavigationButton(modifier : Modifier = Modifier,text: String = "button",onCl
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
+    viewModel: HomeViewmodel = hiltViewModel(),
     controller: NavHostController
 ) {
 
-    val navButtonModifier = Modifier.wrapContentSize().padding(16.dp)
+    val cacheProgress by viewModel.cachingProgress.collectAsStateWithLifecycle()
+
+    val navButtonModifier = Modifier
+        .wrapContentSize()
+        .padding(16.dp)
 
     Box(modifier = modifier) {
         Image(
@@ -79,6 +87,7 @@ fun HomeScreen(
             ) {
                 controller.navigate(route = "collection")
             }
+            Text(text = "$cacheProgress")
         }
     }
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeScreen.kt
@@ -90,7 +90,10 @@ fun HomeScreen(
                     Text(text = "Loading: $cacheProgress%")
                     LoadingAnimation(
                         modifier = Modifier
-                            .padding(start = 10.dp)
+                            .padding(start = 10.dp, top = 10.dp),
+                        circleSize = 15.dp,
+                        spaceBetween = 5.dp,
+                        travelDistance = 15.dp
                     )
                 }
             } else {

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
@@ -1,0 +1,41 @@
+package ar.edu.unlam.mobile.scaffold.ui.screens.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ar.edu.unlam.mobile.scaffold.data.repository.IHeroRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+@HiltViewModel
+class HomeViewmodel @Inject constructor(private val repo : IHeroRepository) : ViewModel() {
+
+    private val _cachingProgress = MutableStateFlow(0.00f)
+    val cachingProgress = _cachingProgress.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            preloadHeroes()
+        }
+    }
+
+    private suspend fun preloadHeroes() {
+        withContext(Dispatchers.IO) {
+            val cachingProgressFlow = repo.preloadHeroCache()
+            cachingProgressFlow.map {
+                (it * 100).roundToInt() / 100f
+            }
+                .collect() { progress ->
+                    _cachingProgress.value = progress
+                }
+        }
+    }
+
+
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
@@ -7,11 +7,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 @HiltViewModel
 class HomeViewmodel @Inject constructor(private val repo: IHeroRepository) : ViewModel() {
@@ -28,9 +26,7 @@ class HomeViewmodel @Inject constructor(private val repo: IHeroRepository) : Vie
     private suspend fun preloadHeroes() {
         withContext(Dispatchers.IO) {
             val cachingProgressFlow = repo.preloadHeroCache()
-            cachingProgressFlow.map {
-                (it * 10000).roundToInt() / 10000f
-            }
+            cachingProgressFlow
                 .collect { progress ->
                     _cachingProgress.value = progress
                 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 
 @HiltViewModel
-class HomeViewmodel @Inject constructor(private val repo : IHeroRepository) : ViewModel() {
+class HomeViewmodel @Inject constructor(private val repo: IHeroRepository) : ViewModel() {
 
     private val _cachingProgress = MutableStateFlow(0.00f)
     val cachingProgress = _cachingProgress.asStateFlow()
@@ -31,11 +31,9 @@ class HomeViewmodel @Inject constructor(private val repo : IHeroRepository) : Vi
             cachingProgressFlow.map {
                 (it * 100).roundToInt() / 100f
             }
-                .collect() { progress ->
+                .collect { progress ->
                     _cachingProgress.value = progress
                 }
         }
     }
-
-
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/ui/screens/home/HomeViewmodel.kt
@@ -29,7 +29,7 @@ class HomeViewmodel @Inject constructor(private val repo: IHeroRepository) : Vie
         withContext(Dispatchers.IO) {
             val cachingProgressFlow = repo.preloadHeroCache()
             cachingProgressFlow.map {
-                (it * 100).roundToInt() / 100f
+                (it * 10000).roundToInt() / 10000f
             }
                 .collect { progress ->
                     _cachingProgress.value = progress


### PR DESCRIPTION
Se ha creado un sistema de cacheo simple que incluye lo siguiente:
- Descarga de todos los personajes al ingresar al HomeScreen.
- Se desabilita el acceso a CollectionScreen hasta que no termine el proceso de cacheo.
- Creado una barra de carga con animaciones simples.
- Creada la animación de tres puntos moviendose para indicar que el proceso no se ha congelado.
- Y otras modificaciones al código base por culpa de detekt.