### PR TITLE
Testeo y arreglos de HeroRepository

### DIFF
--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepository.kt
@@ -65,6 +65,9 @@ class HeroRepository @Inject constructor(private val api: HeroService, private v
     }
 
     override suspend fun getHero(heroId: Int): DataHero {
+        if (heroId < 1 || heroId > COLLECTION_MAX_SIZE) {
+            throw HeroRepositoryException("Hero id outside of range [1,$COLLECTION_MAX_SIZE].")
+        }
         return withContext(Dispatchers.IO) {
             val heroDB = dataBase.getHero(heroId)
             if (heroDB != null) {

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepositoryException.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/HeroRepositoryException.kt
@@ -1,0 +1,8 @@
+package ar.edu.unlam.mobile.scaffold.data.repository
+
+/*
+https://stackoverflow.com/a/68775013
+ */
+class HeroRepositoryException(message: String? = null, cause: Throwable? = null) : Exception(message, cause) {
+    constructor(cause: Throwable) : this(null, cause)
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/IHeroRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffold/data/repository/IHeroRepository.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface IHeroRepository {
 
-    suspend fun getRandomPlayerDeck(size:Int): List<DataHero>
-    suspend fun getAdversaryDeck(size:Int): List<DataHero>
-    suspend fun getHero(heroId:Int): DataHero
-    suspend fun getAllHero():List<DataHero>
+    suspend fun getRandomPlayerDeck(size: Int): List<DataHero>
+    suspend fun getAdversaryDeck(size: Int): List<DataHero>
+    suspend fun getHero(heroId: Int): DataHero
+    suspend fun getAllHero(): List<DataHero>
     fun preloadHeroCache(): Flow<Float>
 }

--- a/app/src/test/java/ar/edu/unlam/mobile/scaffold/repository/HeroRepositoryTest.kt
+++ b/app/src/test/java/ar/edu/unlam/mobile/scaffold/repository/HeroRepositoryTest.kt
@@ -1,12 +1,11 @@
 package ar.edu.unlam.mobile.scaffold.repository
 
-
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import ar.edu.unlam.mobile.scaffold.data.database.dao.HeroDao
 import ar.edu.unlam.mobile.scaffold.data.database.entities.HeroEntity
 import ar.edu.unlam.mobile.scaffold.data.network.HeroService
 import ar.edu.unlam.mobile.scaffold.data.repository.HeroRepository
+import ar.edu.unlam.mobile.scaffold.data.repository.HeroRepositoryException
 import ar.edu.unlam.mobile.scaffold.domain.hero.DataHero
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
@@ -66,9 +65,35 @@ class HeroRepositoryTest {
         coEvery { api.getHero(1) } returns DataHero(id = "2")
         coEvery { db.getHero(1) } returns expectedHeroEntity
 
-        val repo = HeroRepository(api,db)
+        val repo = HeroRepository(api, db)
         val hero = repo.getHero(1)
 
         assertThat(hero).isEqualTo(expectedHero)
     }
+
+    @Test(expected = HeroRepositoryException::class)
+    fun whenProvidingHeroIdLowerThanOneThrowHeroRepositoryException() = runTest {
+        HeroRepository(api, db).getHero(0)
+    }
+
+    @Test(expected = HeroRepositoryException::class)
+    fun whenProvidingHeroIdHigherThan731ThrowHeroRepositoryException() = runTest {
+        HeroRepository(api, db).getHero(732)
+    }
+
+    @Test
+    fun whenDatabaseHas731EntriesReturnListDirectlyWithSize731() = runTest {
+        val expectedSize = 731
+        val heroEntityList: MutableList<HeroEntity> = mutableListOf()
+        for (i in 1..expectedSize) {
+            heroEntityList.add(HeroEntity(id = i, name = "$i test"))
+        }
+        coEvery { db.getAll() } returns heroEntityList
+        val listSize = HeroRepository(api, db).getAllHero().size
+        assertThat(listSize).isEqualTo(expectedSize)
+    }
+/*
+@Test
+    fun whenDatabaseHasZeroEntriesReturn
+ */
 }


### PR DESCRIPTION
Testeados los casos felices y tristes.
Faltan los casos límites y que el repositorio devuelva exactamente el mismo DataHero si proviene de retrofit o de room.