### PR TITLE
Creados unit test de HeroDatabase con robolectric.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,9 @@ android {
             merges += "META-INF/LICENSE-notice.md"
         }
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -72,6 +75,10 @@ dependencies {
     androidTestImplementation 'androidx.arch.core:core-testing:2.2.0'
     androidTestImplementation 'app.cash.turbine:turbine:1.0.0' // testeo simple de flows
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
+
+    // Roboelectric para testear room en unit tests
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation "org.robolectric:annotations:4.11.1"
 
     // Mockk
     def mockkVersion = "1.13.7"

--- a/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
+++ b/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
@@ -13,6 +13,7 @@ import ar.edu.unlam.mobile.scaffold.data.database.entities.PowerstatsEntity
 import ar.edu.unlam.mobile.scaffold.data.database.entities.WorkEntity
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,6 +42,11 @@ class HeroDataBaseTest {
             ).allowMainThreadQueries()
             .build()
         heroDao = heroDataBase.getHeroDao()
+    }
+
+    @After
+    fun tearDown() {
+        heroDataBase.close()
     }
 
     @Test

--- a/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
+++ b/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
@@ -1,0 +1,68 @@
+package ar.edu.unlam.mobile.scaffold.data.database
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import ar.edu.unlam.mobile.scaffold.data.database.dao.HeroDao
+import ar.edu.unlam.mobile.scaffold.data.database.entities.AppearanceEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.BiographyEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.ConnectionsEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.HeroEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.ImageEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.PowerstatsEntity
+import ar.edu.unlam.mobile.scaffold.data.database.entities.WorkEntity
+import com.google.common.truth.Truth
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [31])
+class HeroDataBaseTest {
+
+    @get:Rule
+    var instantTaskExecutor = InstantTaskExecutorRule()
+
+    private lateinit var heroDataBase: HeroDataBase
+    private lateinit var heroDao: HeroDao
+
+    @Before
+    fun setUp() {
+        // val context = ApplicationProvider.getApplicationContext<Context>()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        heroDataBase = Room
+            .inMemoryDatabaseBuilder(
+                context = context,
+                klass = HeroDataBase::class.java
+            ).allowMainThreadQueries()
+            .build()
+        heroDao = heroDataBase.getHeroDao()
+    }
+
+    @Test
+    fun insertHeroEntity() = runTest {
+        val heroEntity = HeroEntity(
+            id = 1,
+            powerstats = PowerstatsEntity(),
+            connections = ConnectionsEntity(),
+            appearance = AppearanceEntity(),
+            biography = BiographyEntity(),
+            image = ImageEntity(),
+            name = "Mr. Test",
+            work = WorkEntity()
+        )
+
+        heroDao.insertHero(hero = heroEntity)
+
+        val allHeroes = heroDao.getAll()
+
+        Truth.assertThat(allHeroes).contains(heroEntity)
+        Truth.assertThat(allHeroes).containsExactly(heroEntity)
+        Truth.assertThat(allHeroes).hasSize(1)
+        Truth.assertThat(allHeroes).isNotEmpty()
+    }
+}

--- a/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
+++ b/app/src/test/java/ar/edu/unlam/mobile/scaffold/data/database/HeroDataBaseTest.kt
@@ -11,7 +11,7 @@ import ar.edu.unlam.mobile.scaffold.data.database.entities.HeroEntity
 import ar.edu.unlam.mobile.scaffold.data.database.entities.ImageEntity
 import ar.edu.unlam.mobile.scaffold.data.database.entities.PowerstatsEntity
 import ar.edu.unlam.mobile.scaffold.data.database.entities.WorkEntity
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -21,7 +21,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [31])
+@Config(sdk = [31]) // robolectric no funciona con los últimos sdk
 class HeroDataBaseTest {
 
     @get:Rule
@@ -44,8 +44,8 @@ class HeroDataBaseTest {
     }
 
     @Test
-    fun insertHeroEntity() = runTest {
-        val heroEntity = HeroEntity(
+    fun whenInsertAHeroEntityInDB_VerifyIfItWasInsertedInDB() = runTest {
+        val expectedHero = HeroEntity(
             id = 1,
             powerstats = PowerstatsEntity(),
             connections = ConnectionsEntity(),
@@ -56,13 +56,69 @@ class HeroDataBaseTest {
             work = WorkEntity()
         )
 
-        heroDao.insertHero(hero = heroEntity)
+        heroDao.insertHero(hero = expectedHero)
 
         val allHeroes = heroDao.getAll()
+        val hero = heroDao.getHero(expectedHero.id)
 
-        Truth.assertThat(allHeroes).contains(heroEntity)
-        Truth.assertThat(allHeroes).containsExactly(heroEntity)
-        Truth.assertThat(allHeroes).hasSize(1)
-        Truth.assertThat(allHeroes).isNotEmpty()
+        assertThat(allHeroes).contains(expectedHero)
+        assertThat(allHeroes).containsExactly(expectedHero)
+        assertThat(allHeroes).hasSize(1)
+        assertThat(allHeroes).isNotEmpty()
+        assertThat(hero).isEqualTo(expectedHero)
+    }
+
+    private val heroEntityList = listOf(
+        HeroEntity(
+            id = 1,
+            powerstats = PowerstatsEntity(),
+            connections = ConnectionsEntity(),
+            appearance = AppearanceEntity(),
+            biography = BiographyEntity(),
+            image = ImageEntity(),
+            name = "Mr. Test 1",
+            work = WorkEntity()
+        ),
+        HeroEntity(
+            id = 2,
+            powerstats = PowerstatsEntity(),
+            connections = ConnectionsEntity(),
+            appearance = AppearanceEntity(),
+            biography = BiographyEntity(),
+            image = ImageEntity(),
+            name = "Mr. Test 2",
+            work = WorkEntity()
+        ),
+        HeroEntity(
+            id = 3,
+            powerstats = PowerstatsEntity(),
+            connections = ConnectionsEntity(),
+            appearance = AppearanceEntity(),
+            biography = BiographyEntity(),
+            image = ImageEntity(),
+            name = "Mr. Test 3",
+            work = WorkEntity()
+        ),
+        HeroEntity(
+            id = 4,
+            powerstats = PowerstatsEntity(),
+            connections = ConnectionsEntity(),
+            appearance = AppearanceEntity(),
+            biography = BiographyEntity(),
+            image = ImageEntity(),
+            name = "Mr. Test 4",
+            work = WorkEntity()
+        )
+    )
+
+    @Test
+    fun whenInsertingAHeroEntityListInDB_VerifyIfTheListWasInserted() = runTest {
+        heroDao.insertAll(heroEntityList)
+        val heroList = heroDao.getAll()
+
+        assertThat(heroList).hasSize(heroEntityList.size)
+        for (i in heroList.indices) {
+            assertThat(heroList[i]).isEqualTo(heroEntityList[i])
+        }
     }
 }


### PR DESCRIPTION
Los test instrumentados (androidTest), que se habían desarrollado anteriormente, no son considerados para calcular el porcentaje de cobertura.... por eso surgió la necesidad de crear test unitarios de room con robolectric.

Lamentablemente, testear room de esta manera tiene el siguiente problema:
- los test unitarios de room utilizando robolectric no funcionan en windows porque este S.O. no posee el mismo sistema de archivos que android/linux/mac.

El bot/workflow de github no se quejó..... así que supongo que está corriendo en un servidor linux.

Solamente room posee este problema.....

Falta experimentar si con robolectric se pueden testear los composables.
